### PR TITLE
Fix mobile profile view

### DIFF
--- a/frontend/src/components/Profile.js
+++ b/frontend/src/components/Profile.js
@@ -127,7 +127,7 @@ class Profile extends React.Component {
       <div className="profile-page">
         <div className="container">
           <div className="row p-4 text-center">
-            <div className="user-info col-xs-12 col-md-8 offset-md-2">
+            <div className="col-xs-12 col-md-8 offset-md-2">
               <img
                 src={profile.image}
                 className="user-img"

--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -55,7 +55,3 @@ body {
   display: -webkit-box;
   -webkit-box-orient: vertical;
 }
-
-.user-info {
-  min-width: 800px;
-}


### PR DESCRIPTION
When viewing the profile page on a mobile device the user info was set
off to the right due to a min-width in css being set. Removing this
allows views on all devices to stay centered within the container.
