### PR TITLE
Show placeholder item image

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || "placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
If an image is not included we want to show the placeholder image in its
place.

![image](https://user-images.githubusercontent.com/329205/190915458-883c71cd-a43f-4dd6-86e3-7efff0f02ec5.png)
